### PR TITLE
Fix return calculation base

### DIFF
--- a/ai_investor_app.py
+++ b/ai_investor_app.py
@@ -77,7 +77,7 @@ else:
             st.subheader("Simulert verdiutvikling")
             st.line_chart(portfolio)
             st.write(f"Sluttverdi: {portfolio[-1]:.2f} kr")
-            st.write(f"Avkastning: {((portfolio[-1] - 10000) / 100):.2f}%")
+            st.write(f"Avkastning: {((portfolio[-1] - 10000) / 10000):.2f}%")
         else:
             st.warning("Ingen data tilgjengelig for simulering.")
     else:


### PR DESCRIPTION
## Summary
- Correct return calculation to divide by the initial capital of 10000 instead of 100

## Testing
- `python -m py_compile ai_investor_app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad610d26e083239f6476bbcf42f71e